### PR TITLE
Update mariner.rst

### DIFF
--- a/docs/mariner.rst
+++ b/docs/mariner.rst
@@ -152,7 +152,7 @@ Supported messages (identified by message type) are:
 
   * `register_events`
 
-    List of register events.
+    List of registered event types.
 
 * `register_res`
 
@@ -170,7 +170,7 @@ Supported messages (identified by message type) are:
 
   * `events`
 
-    List of associated events available only in case of success ``true``.
+    List of associated event types available only in case of success ``true``.
 
 * `query_req`
 


### PR DESCRIPTION
Line 155 - the client registers for new event types, not for new event instances, Line 173 - the server responds with newly registered event types, not with newly created event instances.